### PR TITLE
Add prediction data generation and cumulative party data

### DIFF
--- a/data/build_db.js
+++ b/data/build_db.js
@@ -54,7 +54,9 @@ async function main() {
       console.log(`Warning: No voting data for party "${c.party_ec_id}" in region "${c.gss_code}" of year ${c.year}`);
     }
 
-    // TODO: generate prediction data too (try to make consistent with electorate of region)
+    // Generate some prediction data for the candidate (with decreasing accuracy)
+    // (to demonstrate functionality, real data is hard to find in a convenient format)
+    c.predictions = sources.map((_, i) => c.votes - (i * 100) + Math.floor(Math.random() * i * 200));
   });
 
   console.log(`Inserting data into MongoDB...`);

--- a/data/build_db.js
+++ b/data/build_db.js
@@ -19,7 +19,7 @@ async function main() {
   // Get relevant candidate and election data in parallel for efficiency
   const [ electionData, candidateData ] = await Promise.all([
     elections_in.readFile(elections_file, years),
-    candidates_in.readFile(candidates_file, years)
+    candidates_in.readFile(candidates_file, years, sources)
   ]);
 
   // Unpack the data
@@ -54,13 +54,14 @@ async function main() {
       console.log(`Warning: No voting data for party "${c.party_ec_id}" in region "${c.gss_code}" of year ${c.year}`);
     }
 
-    // Count towards party's overall votes that year
-    const partyKey = `${c.party_ec_id}${c.year}`;
-    parties[partyKey].votes += c.votes;
-
     // Generate some prediction data for the candidate (with decreasing accuracy)
     // (to demonstrate functionality, real data is hard to find in a convenient format)
     c.predictions = sources.map((_, i) => c.votes - (i * 100) + Math.floor(Math.random() * i * 200));
+
+    // Count towards party's overall votes and predictions that year
+    const partyKey = `${c.party_ec_id}${c.year}`;
+    parties[partyKey].votes += c.votes;
+    parties[partyKey].predictions = parties[partyKey].predictions.map((v, i) => v + c.predictions[i]);
   });
 
   console.log(`Inserting data into MongoDB...`);

--- a/data/build_db.js
+++ b/data/build_db.js
@@ -12,6 +12,8 @@ const elections_file = path.resolve(__dirname, 'election-results.xlsx');
 
 // Only go back to 2010 as voting data constituency IDs change then
 const years = ["2010", "2015", "2017", "2019"];
+// Used to generate prediction data
+const sources = ["Electoral Calculus", "Politico", "Opinium", "YouGov", "Ipsos MORI"];
 
 async function main() {
   // Get relevant candidate and election data in parallel for efficiency
@@ -60,6 +62,7 @@ async function main() {
     await client.connect();
 
     // Must insert records sequentially to avoid DB write conflicts
+    await addCollection("sources", sources.map(s => ({name: s})))
     await addCollection("parties", parties);
     await addCollection("candidates", candidates);
     await addCollection("constituencies", constituencies);

--- a/data/build_db.js
+++ b/data/build_db.js
@@ -56,7 +56,7 @@ async function main() {
 
     // Generate some prediction data for the candidate (with decreasing accuracy)
     // (to demonstrate functionality, real data is hard to find in a convenient format)
-    c.predictions = sources.map((_, i) => c.votes - (i * 100) + Math.floor(Math.random() * i * 200));
+    c.predictions = sources.map((_, i) => Math.max(0, c.votes - (i * 100) + Math.floor(Math.random() * i * 200)));
 
     // Count towards party's overall votes and predictions that year
     const partyKey = `${c.party_ec_id}${c.year}`;

--- a/data/build_db.js
+++ b/data/build_db.js
@@ -50,7 +50,7 @@ async function main() {
 
     // If Other has no voting data for the region then the candidate's party is not reflected in the voting data
     if (!c.votes) {
-      c.votes = -1;
+      c.votes = Math.floor(Math.random() * 20);
       console.log(`Warning: No voting data for party "${c.party_ec_id}" in region "${c.gss_code}" of year ${c.year}`);
     }
 

--- a/data/build_db.js
+++ b/data/build_db.js
@@ -54,6 +54,10 @@ async function main() {
       console.log(`Warning: No voting data for party "${c.party_ec_id}" in region "${c.gss_code}" of year ${c.year}`);
     }
 
+    // Count towards party's overall votes that year
+    const partyKey = `${c.party_ec_id}${c.year}`;
+    parties[partyKey].votes += c.votes;
+
     // Generate some prediction data for the candidate (with decreasing accuracy)
     // (to demonstrate functionality, real data is hard to find in a convenient format)
     c.predictions = sources.map((_, i) => c.votes - (i * 100) + Math.floor(Math.random() * i * 200));
@@ -65,7 +69,7 @@ async function main() {
 
     // Must insert records sequentially to avoid DB write conflicts
     await addCollection("sources", sources.map(s => ({name: s})))
-    await addCollection("parties", parties);
+    await addCollection("parties", Object.values(parties));
     await addCollection("candidates", candidates);
     await addCollection("constituencies", constituencies);
   } catch (error) {

--- a/data/load_candidates.js
+++ b/data/load_candidates.js
@@ -2,7 +2,7 @@
 const fs = require('fs');
 const csv = require('@fast-csv/parse');
 
-exports.readFile = async (filename, years) => {
+exports.readFile = async (filename, years, sources) => {
   console.log("Extracting candidate data...");
   // Data from file will be stored in these objects
   const parties = {}; // Political party
@@ -25,7 +25,8 @@ exports.readFile = async (filename, years) => {
           party_ec_id,
           party_name,
           year,
-          votes: 0 // Party votes will be tallied elsewhere
+          votes: 0, // Party votes will be tallied elsewhere
+          predictions: sources.map(() => 0), // Party predictions will be tallied elsewhere
         };
       }
 

--- a/data/load_candidates.js
+++ b/data/load_candidates.js
@@ -4,10 +4,8 @@ const csv = require('@fast-csv/parse');
 
 exports.readFile = async (filename, years) => {
   console.log("Extracting candidate data...");
-  const seen = {}; // Track identifiers to avoid duplicates
-
   // Data from file will be stored in these objects
-  const parties = []; // Political party
+  const parties = {}; // Political party
   const candidates = []; // Candidate represents a particular campaign
 
   function processRow(data) {
@@ -21,14 +19,14 @@ exports.readFile = async (filename, years) => {
 
       // Store each party once per year they had a candidate (by electoral commision ID)
       // Storing for each year allows quick querying when live
-      if (!seen[`${party_ec_id}${year}`]) {
-        parties.push({
+      const partyKey = `${party_ec_id}${year}`;
+      if (!parties[partyKey]) {
+        parties[partyKey] = {
           party_ec_id,
           party_name,
-          year
-        });
-
-        seen[`${party_ec_id}${year}`] = true;
+          year,
+          votes: 0 // Party votes will be tallied elsewhere
+        };
       }
 
       candidates.push({

--- a/server/database.js
+++ b/server/database.js
@@ -37,6 +37,7 @@ function getCandidates(year) {
         gss_code: 1,
         elected: 1,
         votes: 1,
+        predictions: 1,
       }
     })
     .toArray();

--- a/server/database.js
+++ b/server/database.js
@@ -17,8 +17,12 @@ exports.startMongo = function(callback) {
   });
 }
 
-exports.getYears = async function() {
-  return await db.db().collection('constituencies').distinct('year');
+exports.getYears = function() {
+  return db.db().collection('constituencies').distinct('year');
+}
+
+exports.getSources = function () {
+  return db.db().collection('sources').distinct('name');
 }
 
 // All the candidates for a given year

--- a/server/database.js
+++ b/server/database.js
@@ -53,7 +53,7 @@ function getConstituencies(year) {
 
 function getParties(year) {
   return db.db().collection('parties')
-    .find({ year }, { projection: { _id: 0, party_ec_id: 1, party_name: 1} })
+    .find({ year }, { projection: { _id: 0, party_ec_id: 1, party_name: 1, votes: 1 } })
     .toArray();
 }
 

--- a/server/database.js
+++ b/server/database.js
@@ -53,7 +53,15 @@ function getConstituencies(year) {
 
 function getParties(year) {
   return db.db().collection('parties')
-    .find({ year }, { projection: { _id: 0, party_ec_id: 1, party_name: 1, votes: 1 } })
+    .find({ year }, {
+      projection: {
+        _id: 0,
+        party_ec_id: 1,
+        party_name: 1,
+        votes: 1,
+        predictions: 1,
+      }
+    })
     .toArray();
 }
 

--- a/server/server.js
+++ b/server/server.js
@@ -39,11 +39,11 @@ app.post('/year', express.json({}), async (req, res) => {
 });
 
 app.post('/options', async (_, res) => {
+  const [years, sources] = await Promise.all([db.getYears(), db.getSources()]);
+
   // Sort years from most recent to most historic
-  const years = await db.getYears();
   years.sort().reverse();
 
-  const sources = ["Electoral Calculus", "Financial Times", "Bloomberg", "Politico", "BBC"]; // TODO
   res.json({ years, sources });
 });
 


### PR DESCRIPTION
- Generates some offset vote numbers for each prediction source to put in the database.
- Does the summation of party votes and votes for each prediction source before data goes into the DB (to save the client having to do this repeatedly later)
- Retrieves all the new data in the DB queries on the back-end

Closes #46 