### PR TITLE
Safeguard against NoSQL queries with non-strings

### DIFF
--- a/server/database.js
+++ b/server/database.js
@@ -94,6 +94,9 @@ function getParties(year) {
 }
 
 exports.getData = async function(year) {
+  // Avoid NoSQL injection by enforcing year to be a string
+  if (typeof year !== 'string') return;
+
   // Check year exists in the DB before any extensive querying
   if (!(await db.db().collection('candidates').findOne({ year }))) return;
 


### PR DESCRIPTION
This is already pretty well guarded against (server.js checks for a year string), but just another layer of protection against malicious queries from the client (if they were to try sending an object as the query).