### PR TITLE
Introduce data cache to front end

### DIFF
--- a/public/src/candidate.js
+++ b/public/src/candidate.js
@@ -1,10 +1,9 @@
 /* global Chart */ // Defined by Chart.js
 
+import { getData } from './data.js';
+
 // Chart will be updated later
 let chart;
-
-// Data will be stored for future updates
-let cached;
 
 export function initCandidate() {
   const ctx = document.getElementById('candGraph').getContext('2d');
@@ -31,28 +30,27 @@ export function initCandidate() {
   });
 }
 
-export function populateCandidate(data) {
-  cached = data;
-
+export function populateCandidate() {
   // For now default to first in the list
   updateCandidate(0);
 }
 
 export function updateCandidate(index) {
-  const chosen = cached.candidates[index];
+  const data = getData();
+  const chosen = data.candidates[index];
 
   updateChart(chosen);
 
   document.getElementById('candName').innerHTML = chosen.name;
-  document.getElementById('candParty').innerHTML = cached.parties.find(p => p.party_ec_id === chosen.party_ec_id).party_name;
-  document.getElementById('candConst').innerHTML = cached.constituencies.find(c => c.gss_code === chosen.gss_code).name;
+  document.getElementById('candParty').innerHTML = data.parties.find(p => p.party_ec_id === chosen.party_ec_id).party_name;
+  document.getElementById('candConst').innerHTML = data.constituencies.find(c => c.gss_code === chosen.gss_code).name;
   document.getElementById('candCamps').innerHTML = 1; // TODO get number of runs
   document.getElementById('candElect').innerHTML = 1; // TODO get this
 }
 
 function updateChart(chosen) {
   // Compare to candidates in same constituency
-  const competitors = cached.candidates.filter(c => (c.gss_code === chosen.gss_code) && (c.party_ec_id !== chosen.party_ec_id));
+  const competitors = getData().candidates.filter(c => (c.gss_code === chosen.gss_code) && (c.party_ec_id !== chosen.party_ec_id));
 
   // Sort competitors by votes
   competitors.sort((a, b) => b.votes - a.votes);

--- a/public/src/data.js
+++ b/public/src/data.js
@@ -1,0 +1,9 @@
+// Data will be stored here to prevent repeated requests
+export const cache = {};
+
+// Year context tracked for element update data requests
+export let curYear;
+
+export function setYear(year) {
+  curYear = year;
+}

--- a/public/src/data.js
+++ b/public/src/data.js
@@ -1,9 +1,21 @@
 // Data will be stored here to prevent repeated requests
 export const cache = {};
 
-// Year context tracked for element update data requests
+// Year context tracked for element updates
 export let curYear;
+
+// Source context tracked for element updates (map toggle and graph)
+export let curSource;
 
 export function setYear(year) {
   curYear = year;
+}
+
+export function setSource(index) {
+  curSource = index;
+}
+
+// Convenience function to get current year's data
+export function getData() {
+  return cache[curYear];
 }

--- a/public/src/dropdowns.js
+++ b/public/src/dropdowns.js
@@ -1,5 +1,5 @@
-import { newYear } from './requests.js';
 import { updatePredictions } from './graph.js';
+import { newYear } from './requests.js';
 
 // Populates a dropdown (identified by ID in HTML) with array of values
 async function populateDropdown(id, options, index = false) {

--- a/public/src/graph.js
+++ b/public/src/graph.js
@@ -1,11 +1,12 @@
 /* global Chart */ // Defined by Chart.js
 
+import { curSource, getData, setSource } from "./data";
+
 // Chart will be updated later
 let chart;
 
 // Prediction data can be switched between after load
 const predictions = [];
-let predictIndex = 0; // Index should persist when year changes
 
 // Reference: https://www.chartjs.org/docs/latest/
 export async function initGraph() {
@@ -43,21 +44,26 @@ function populatePredictions(top6, rest) {
   }
 }
 
-export async function populateGraph(data) {
-  // Get the most popular 6 parties
-  data.sort((a, b) => b.votes - a.votes);
+export async function populateGraph() {
+  // Ignore the independent entry (not a true party)
+  const parties = getData().parties.filter(p => p.party_ec_id.startsWith('PP'));
 
-  const top6 = data.slice(0,6);
+  // Get the most popular 6 parties
+  parties.sort((a, b) => b.votes - a.votes);
+  const top6 = parties.slice(0,6);
+
+  // Sort by name for graph display
   top6.sort((a, b) => a.party_name.localeCompare(b.party_name));
 
-  const rest = data.slice(6);
+  // All the rest will be grouped under "Other"
+  const rest = parties.slice(6);
 
   chart.data.labels = top6.map(p => p.party_name);
   chart.data.labels.push('Other');
 
   // Cumulate remaining party votes under "Other" entry
-  const dataReal = top6.map(p => p.votes);
-  dataReal.push(rest.reduce((acc, cur) => acc + cur.votes, 0));
+  const data = top6.map(p => p.votes);
+  data.push(rest.reduce((acc, cur) => acc + cur.votes, 0));
 
   const partyColours = top6.map(p => p.colour ? p.colour : '#3C4750');
   partyColours.push('#3C4750'); // "Other" gets neutral styling
@@ -74,15 +80,15 @@ export async function populateGraph(data) {
     borderWidth: 1,
     backgroundColor: partyColours,
     borderColor: "#3C4750",
-    data: dataReal
+    data
   };
 
   // Update displayed predictions, preserving current index
-  updatePredictions(predictIndex);
+  updatePredictions(curSource);
 }
 
 export async function updatePredictions(index) {
-  predictIndex = index;
+  setSource(index);
 
   // Show prediction data as an outline only bar to differentiate
   chart.data.datasets[1] = {

--- a/public/src/list.js
+++ b/public/src/list.js
@@ -1,3 +1,5 @@
+import { getData } from "./data";
+
 function search() {
   const input = document.getElementById("search");
   const filter = input.value.toUpperCase();
@@ -23,14 +25,14 @@ export async function initSearch() {
 }
 
 // Clears and populates the list with the data passed in
-export async function populateList(data) {
+export async function populateList() {
   // Clear existing rows first
   const [clist] = document.getElementById('candList').getElementsByTagName('tbody');
   clist.innerHTML = '';
 
   // Document fragment will trigger reflow only once when attached
   const newRows = document.createDocumentFragment();
-  data.forEach(cand => {
+  getData().candidates.forEach(cand => {
     const row = document.createElement("tr");
     const name = document.createElement("td");
     const votes = document.createElement("td");
@@ -50,12 +52,12 @@ export async function populateList(data) {
   clist.appendChild(newRows);
 }
 
-export async function populateLegend(data) {
+export async function populateLegend() {
   const [llist] = document.getElementById('legend').getElementsByTagName('tbody');
   llist.innerHTML = '';
 
   // Legend only needed for parties with colours
-  const significant = data.filter(p => p.colour);
+  const significant = getData().parties.filter(p => p.colour);
 
   // Update the stylesheet to colour party classed elements
   const css = document.getElementById('party-styling');

--- a/public/src/main.js
+++ b/public/src/main.js
@@ -1,9 +1,9 @@
-import { getOptions, newYear } from './requests.js';
-import { initMap } from './map.js';
-import { initDropdowns, populateDropdowns } from './dropdowns.js';
-import { initSearch, initSort } from './list.js';
-import { initGraph } from './graph.js';
 import { initCandidate } from './candidate.js';
+import { initDropdowns, populateDropdowns } from './dropdowns.js';
+import { initGraph } from './graph.js';
+import { initSearch, initSort } from './list.js';
+import { initMap } from './map.js';
+import { getOptions, newYear } from './requests.js';
 
 // Leave this blank, value injected during build (see contributing guidelines)
 const MAPBOX_KEY = '';

--- a/public/src/requests.js
+++ b/public/src/requests.js
@@ -2,6 +2,9 @@ import { populateList, populateLegend } from './list.js';
 import { populateGraph } from './graph.js';
 import { populateCandidate } from './candidate.js';
 
+// Data will be stored here to prevent repeated requests
+const cache = {};
+
 export function getOptions() {
   return new Promise((resolve, reject) => {
     const xhttp = new XMLHttpRequest();
@@ -22,13 +25,17 @@ export function getOptions() {
 }
 
 function getYear(year) {
+  // No need to repeat requests
+  if (year in cache) return cache[year];
+
   return new Promise((resolve, reject) => {
     const xhttp = new XMLHttpRequest();
     xhttp.onreadystatechange = function () {
       if (this.readyState === 4) {
         // Successful request
         if (this.status === 200) {
-          resolve(JSON.parse(this.responseText));
+          cache[year] = JSON.parse(this.responseText);
+          resolve(cache[year]);
         } else {
           reject(this.status);
         }
@@ -39,11 +46,10 @@ function getYear(year) {
     xhttp.setRequestHeader("Content-Type", "application/json");
 
     xhttp.send(JSON.stringify({ year }));
-  })
+  });
 }
 
 // TODO: make spinners for the unpopulated elements while waiting
-// TODO: Cache year data to avoid repeated requests
 export async function newYear(year) {
   const data = await getYear(year);
 

--- a/public/src/requests.js
+++ b/public/src/requests.js
@@ -52,14 +52,12 @@ export async function newYear(year) {
     cache[year] = await getYear(year);
   }
 
-  const data = cache[year];
-
   // Asynchronous code means a new year could be requested before the data resolves
   // No need to update elements if the desired year now differs
   if (curYear === year) {
-    populateLegend(data.parties);
-    populateList(data.candidates);
-    populateGraph(data.parties);
-    populateCandidate(data);
+    populateLegend();
+    populateList();
+    populateGraph();
+    populateCandidate();
   }
 }

--- a/public/src/requests.js
+++ b/public/src/requests.js
@@ -5,6 +5,9 @@ import { populateCandidate } from './candidate.js';
 // Data will be stored here to prevent repeated requests
 const cache = {};
 
+// Year context tracked for element update data requests
+let curYear;
+
 export function getOptions() {
   return new Promise((resolve, reject) => {
     const xhttp = new XMLHttpRequest();
@@ -51,10 +54,15 @@ function getYear(year) {
 
 // TODO: make spinners for the unpopulated elements while waiting
 export async function newYear(year) {
+  curYear = year;
   const data = await getYear(year);
 
-  populateLegend(data.parties);
-  populateList(data.candidates);
-  populateGraph(data.parties);
-  populateCandidate(data);
+  // Asynchronous code means a new year could be requested before the data resolves
+  // No need to update elements if the desired year now differs
+  if (curYear === year) {
+    populateLegend(data.parties);
+    populateList(data.candidates);
+    populateGraph(data.parties);
+    populateCandidate(data);
+  }
 }


### PR DESCRIPTION
Not much to explain, convenient central location to store information for later access. Will become more relevant as more elements become interactive (e.g. when clicking a candidate the candidate section needs to be able to get the data to update).

I also fixed the "Independent" entry sowing up on the parties graph since I was touching that code as part of this change.

Closes #88 
Closes #84 
