### PR TITLE
Format candidate section

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -113,10 +113,13 @@ main {
   display: flex;
   flex-direction: column;
   max-height: 300px;
+  align-items: center;
 }
 
 #candidate-section table {
-  margin-bottom: 7px;
+  width: 50%;
+  font-size: 80%;
+  margin: 10px 0 30px 0;
 }
 
 /* politician section graph formatting */

--- a/public/index.html
+++ b/public/index.html
@@ -64,9 +64,8 @@
 
     <!-- Politician Profile Section -->
     <div id="candidate-section" >
-      <h4>Candidate Details</h4>
+      <h4 id="candName" ></h4>
       <table>
-        <tr><td>Name:</td><td id="candName"></td></tr>
         <tr><td>Party:</td><td id="candParty"></td></tr>
         <tr><td>Constituency:</td><td id="candConst"></td></tr>
         <tr><td>Campaigns:</td><td id="candCamps"></td></tr>

--- a/public/src/candidate.js
+++ b/public/src/candidate.js
@@ -22,6 +22,7 @@ export function initCandidate() {
             yAxes: [{
               ticks: {
                 beginAtZero: true,
+                stepSize: 20,
                 callback: value => `${value}%`
               }
             }]


### PR DESCRIPTION
Replaced the header with candidate's name, centred elements and fixed tick intervals for y axis (stop from overlapping).
![Screen Shot 2021-03-24 at 14 06 17](https://user-images.githubusercontent.com/71130806/112308186-880fd500-8caa-11eb-889b-9605ded74781.png).
